### PR TITLE
Add .git directory to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+.git/*
 node_modules/*


### PR DESCRIPTION
Since the docker containers don't need the git files, it can just be ignored. This should make container builds a little faster.